### PR TITLE
Update 2020-05-17-customize-github-code-font.md

### DIFF
--- a/_posts/tips/2020-05-17-customize-github-code-font.md
+++ b/_posts/tips/2020-05-17-customize-github-code-font.md
@@ -27,7 +27,7 @@ If you want less or more boldness, decrease or increase this number.
 */
 @import url("https://fonts.googleapis.com/css2?family=Fira+Code:wght@450&display=swap");
 
-pre, code, .blob-code, .blob-code-marker {
+pre, code, .blob-code, .blob-code-content, .blob-code-marker {
   font-family: 'Fira Code', monospace !important;
 }
 ```


### PR DESCRIPTION
I was playing around with Github, trying to change the font, and I noticed that the class for code seems to have changed to `.blob-code-content`.